### PR TITLE
Fix parsing typechecking error with Windows file path

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -91,16 +91,30 @@ class Golangcilint(NodeLinter):
             for line in data["Report"]["Error"].splitlines():
                 if line.count(":") < 3:
                     continue
-                parts = line.split(":")
-                data["Issues"].append({
-                    "FromLinter": "typecheck",
-                    "Text": parts[3].strip(),
-                    "Pos": {
-                        "Filename": parts[0],
-                        "Line": parts[1],
-                        "Column": parts[2],
-                    }
-                })
+                if line.startswith("typechecking error: "):
+                    line = line[20:]
+                if line[1:3] == ":\\": # windows path in filename
+                    parts = line.split(":", 4)
+                    data["Issues"].append({
+                        "FromLinter": "typecheck",
+                        "Text": parts[4].strip(),
+                        "Pos": {
+                            "Filename": ':'.join(parts[0:2]),
+                            "Line": parts[2],
+                            "Column": parts[3],
+                        }
+                    })
+                else:
+                    parts = line.split(":", 3)
+                    data["Issues"].append({
+                        "FromLinter": "typecheck",
+                        "Text": parts[3].strip(),
+                        "Pos": {
+                            "Filename": parts[0],
+                            "Line": parts[1],
+                            "Column": parts[2],
+                        }
+                    })
 
         """find relevant issues and yield a LintMatch"""
         if data and "Issues" in data:


### PR DESCRIPTION
Hello,

When merging stderr with issues, the `parts = line.split(":")` line assumes that the path does not contain any `:` character. This breaks on Windows, and causes a SublimeLinter error:
```
SublimeLinter: ERROR: Unhandled exception:
Traceback (most recent call last):
  File "C:\Users\Florent\AppData\Roaming\Sublime Text 3\Installed Packages\SublimeLinter.sublime-package\lint/backend.py", line 157, in execute_lint_task
    errors = linter.lint(code, view_has_changed)
  File "C:\Users\Florent\AppData\Roaming\Sublime Text 3\Installed Packages\SublimeLinter.sublime-package\lint/linter.py", line 1021, in lint
    return self.filter_errors(self.parse_output(output, virtual_view))
  File "C:\Users\Florent\AppData\Roaming\Sublime Text 3\Installed Packages\SublimeLinter.sublime-package\lint/linter.py", line 1046, in filter_errors
    for error in errors
  File "C:\Users\Florent\AppData\Roaming\Sublime Text 3\Installed Packages\SublimeLinter.sublime-package\lint/linter.py", line 1045, in <listcomp>
    error
  File "C:\Users\Florent\AppData\Roaming\Sublime Text 3\Installed Packages\SublimeLinter.sublime-package\lint/linter.py", line 1084, in parse_output_via_regex
    for m in self.find_errors(output):
  File "C:\Users\Florent\AppData\Roaming\Sublime Text 3\Packages\SublimeLinter-golangcilint\linter.py", line 115, in find_errors
    issue = self._formalize(issue)
  File "C:\Users\Florent\AppData\Roaming\Sublime Text 3\Packages\SublimeLinter-golangcilint\linter.py", line 193, in _formalize
    issue["Pos"]["Line"] = int(issue["Pos"]["Line"])
ValueError: invalid literal for int() with base 10: ' C'
```

I have added a regex (with non greedy matching) that properly matches both Windows and Unix path.

If the regex does not match, the previous code is still ran.

Let me know if you have any comment.
