### PR TITLE
Allow to specify parameters via arguments.

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -2,7 +2,7 @@ from SublimeLinter.lint import Linter, WARNING
 
 
 class GolangCILint(Linter):
-    cmd = 'golangci-lint run --fast --out-format tab ${file_path}'
+    cmd = 'golangci-lint run ${args} --out-format tab ${file_path}'
     tempfile_suffix = '-'
     # Column reporting is optional and not provided by all linters.
     # Issues reported by the 'typecheck' linter are treated as errors,


### PR DESCRIPTION
In current form linter unable to:

* Run all linters (not only fast)
* Use project-wide configuration

This PR allows that with a little salt of specifying `--fast` in args in SublimeLinter configuration.